### PR TITLE
Framebuffer fixes

### DIFF
--- a/FinalEngine.Examples.Sponza/Program.cs
+++ b/FinalEngine.Examples.Sponza/Program.cs
@@ -11,6 +11,7 @@ using FinalEngine.Platform.Desktop.OpenTK;
 using FinalEngine.Platform.Desktop.OpenTK.Invocation;
 using FinalEngine.Rendering.OpenGL;
 using FinalEngine.Rendering.OpenGL.Invocation;
+using FinalEngine.Rendering.Textures;
 using FinalEngine.Rendering.Vapor;
 using FinalEngine.Rendering.Vapor.Core;
 using FinalEngine.Rendering.Vapor.Geometry;
@@ -163,6 +164,23 @@ internal class Program
 
         var modelResource = ResourceManager.Instance.LoadResource<ModelResource>("Resources\\Models\\Dabrovic\\Sponza.obj");
 
+        var colorTarget = renderDevice.Factory.CreateTexture2D<byte>(
+            new Texture2DDescription()
+            {
+                GenerateMipmaps = false,
+                Height = window.ClientSize.Height,
+                Width = window.ClientSize.Width,
+                MinFilter = TextureFilterMode.Linear,
+                MagFilter = TextureFilterMode.Linear,
+                PixelType = PixelType.Byte,
+                WrapS = TextureWrapMode.Clamp,
+                WrapT = TextureWrapMode.Clamp,
+            },
+            null);
+
+        var renderTarget = renderDevice.Factory.CreateFrameBuffer(
+            new[] { colorTarget });
+
         while (isRunning)
         {
             if (!gameTime.CanProcessNextFrame())
@@ -176,6 +194,8 @@ internal class Program
 
             keyboard.Update();
             mouse.Update();
+
+            //renderDevice.Pipeline.SetFrameBuffer(renderTarget);
 
             foreach (var model in modelResource.Models)
             {
@@ -223,6 +243,20 @@ internal class Program
             renderingEngine.Enqueue(light4);
 
             renderingEngine.Render(camera);
+
+            //renderDevice.Pipeline.SetFrameBuffer(null);
+
+            //renderingEngine.Enqueue(new Model()
+            //{
+            //    Mesh = mesh,
+            //    Material = new Material()
+            //    {
+            //        DiffuseTexture = renderTarget.ColorTargets.FirstOrDefault(),
+            //    },
+            //}, new Transform());
+
+            //renderingEngine.Render(camera);
+
             renderContext.SwapBuffers();
             window.ProcessEvents();
         }

--- a/FinalEngine.Rendering.OpenGL/Buffers/IOpenGLFrameBuffer.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/IOpenGLFrameBuffer.cs
@@ -1,9 +1,12 @@
+// <copyright file="IOpenGLFrameBuffer.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
 namespace FinalEngine.Rendering.OpenGL.Buffers;
+
 using FinalEngine.Rendering.Buffers;
 
 public interface IOpenGLFrameBuffer : IFrameBuffer
 {
     void Bind();
-    void UnBind();
 }
-

--- a/FinalEngine.Rendering.OpenGL/Buffers/OpenGLFrameBuffer.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/OpenGLFrameBuffer.cs
@@ -1,90 +1,80 @@
+// <copyright file="OpenGLFrameBuffer.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
 namespace FinalEngine.Rendering.OpenGL.Buffers;
+
 using System;
 using System.Collections.Generic;
-using OpenTK.Graphics.OpenGL4;
+using System.Linq;
+using FinalEngine.Rendering.Buffers;
 using FinalEngine.Rendering.Exceptions;
 using FinalEngine.Rendering.OpenGL.Invocation;
 using FinalEngine.Rendering.OpenGL.Textures;
 using FinalEngine.Rendering.Textures;
-using FinalEngine.Utilities;
+using OpenTK.Graphics.OpenGL4;
 
-
-public class OpenGLFrameBuffer : IOpenGLFrameBuffer
+public class OpenGLFrameBuffer : IFrameBuffer, IOpenGLFrameBuffer, IDisposable
 {
-    private int rendererID;
     private readonly IOpenGLInvoker invoker;
-    public ITexture2D? DepthTarget { get; }
-    public IReadOnlyList<ITexture2D> ColorTargets { get; }
-    public int Width { get; }
-    public int Height { get; }
 
+    private int rendererID;
 
-    protected bool IsDisposed { get; private set; }
-
-    public OpenGLFrameBuffer(IOpenGLInvoker invoker, IEnumMapper mapper, IReadOnlyList<ITexture2D> colorTargets, ITexture2D? depthTarget)
+    public OpenGLFrameBuffer(IOpenGLInvoker invoker, IReadOnlyList<IOpenGLTexture> colorTargets, IOpenGLTexture? depthTarget)
     {
-        this.invoker = invoker ?? throw new ArgumentNullException(nameof(invoker));
-        ArgumentNullException.ThrowIfNull(mapper, nameof(mapper));
         ArgumentNullException.ThrowIfNull(colorTargets, nameof(colorTargets));
-        
-        if (colorTargets is not IReadOnlyList<IOpenGLTexture>)
+        this.invoker = invoker ?? throw new ArgumentNullException(nameof(invoker));
+
+        int maximumColorAttachments = this.invoker.GetInteger(GetPName.MaxColorAttachments);
+
+        if (colorTargets.Count > maximumColorAttachments)
         {
-            throw new ArgumentException(
-                $"The specified {nameof(colorTargets)} parameter is not of type {nameof(IReadOnlyList<IOpenGLTexture>)}.",
-                nameof(colorTargets));
+            throw new FrameBufferTargetException($"The number of {nameof(colorTargets)} should not exceed the maximum number of color attachmemts: '{maximumColorAttachments}'.");
         }
 
-        if (depthTarget is not null && depthTarget is not IOpenGLTexture)
-        {
-            throw new ArgumentException(
-                $"The specified {nameof(depthTarget)} parameter is not of type {nameof(IOpenGLTexture)}.",
-                nameof(depthTarget));
-        }
-
-        this.DepthTarget = depthTarget;
-        this.ColorTargets = colorTargets;
+        this.DepthTarget = (ITexture2D?)depthTarget;
+        this.ColorTargets = colorTargets.Cast<ITexture2D>();
         this.rendererID = invoker.CreateFramebuffer();
 
-        // Color 
         int attachmentCount = colorTargets.Count;
+
         for (int i = 0; i < attachmentCount; i++)
         {
-            ((IOpenGLTexture)colorTargets[i]).Attach(FramebufferAttachment.ColorAttachment0 + i, this.rendererID);
+            colorTargets[i].Attach(FramebufferAttachment.ColorAttachment0 + i, this.rendererID);
         }
+
         Span<DrawBuffersEnum> bufs = stackalloc DrawBuffersEnum[attachmentCount];
+
         for (int i = 0; i < attachmentCount; i++)
         {
             bufs[i] = DrawBuffersEnum.ColorAttachment0 + i;
         }
+
         this.invoker.NamedFramebufferDrawBuffers(this.rendererID, attachmentCount, ref bufs[0]);
-
-        // depth
-        if (depthTarget != null)
-        {
-            ((IOpenGLTexture)depthTarget).Attach(FramebufferAttachment.DepthStencilAttachment, this.rendererID);
-        }
-
+        depthTarget?.Attach(FramebufferAttachment.DepthStencilAttachment, this.rendererID);
 
         var status = invoker.CheckNamedFramebufferStatus(this.rendererID, FramebufferTarget.Framebuffer);
+
         if (status != FramebufferStatus.FramebufferComplete)
         {
             throw new FrameBufferNotCompleteException($"The {nameof(OpenGLFrameBuffer)} is not complete: {status}.");
         }
     }
 
-    public void Bind()
-    {
-        this.invoker.Bindframebuffer(FramebufferTarget.Framebuffer, this.rendererID);
-    }
-
-    public void UnBind()
-    {
-        this.invoker.Bindframebuffer(FramebufferTarget.Framebuffer, 0);
-    }
-
     ~OpenGLFrameBuffer()
     {
         this.Dispose(false);
+    }
+
+    public IEnumerable<ITexture2D> ColorTargets { get; }
+
+    public ITexture2D? DepthTarget { get; }
+
+    protected bool IsDisposed { get; private set; }
+
+    public void Bind()
+    {
+        this.invoker.BindFramebuffer(FramebufferTarget.Framebuffer, this.rendererID);
     }
 
     public void Dispose()
@@ -109,4 +99,3 @@ public class OpenGLFrameBuffer : IOpenGLFrameBuffer
         this.IsDisposed = true;
     }
 }
-

--- a/FinalEngine.Rendering.OpenGL/Invocation/IOpenGLInvoker.cs
+++ b/FinalEngine.Rendering.OpenGL/Invocation/IOpenGLInvoker.cs
@@ -16,7 +16,7 @@ public interface IOpenGLInvoker
 
     void BindBuffer(BufferTarget target, int buffer);
 
-    void Bindframebuffer(FramebufferTarget target, int framebuffers);
+    void BindFramebuffer(FramebufferTarget target, int framebuffers);
 
     void BindTexture(TextureTarget target, int texture);
 
@@ -119,6 +119,8 @@ public interface IOpenGLInvoker
     void NamedBufferSubData<T3>(int buffer, IntPtr offset, int size, T3[] data)
         where T3 : struct;
 
+    void NamedFramebufferDrawBuffers(int fb, int n, ref DrawBuffersEnum bufs);
+
     void NamedFramebufferTexture(int framebuffer, FramebufferAttachment attachment, int texture, int level);
 
     void PolygonMode(MaterialFace face, PolygonMode mode);
@@ -165,6 +167,4 @@ public interface IOpenGLInvoker
     void VertexAttribFormat(int attribindex, int size, VertexAttribType type, bool normalized, int relativeoffset);
 
     void Viewport(Rectangle rectangle);
-
-    void NamedFramebufferDrawBuffers(int fb, int n, ref DrawBuffersEnum bufs);
 }

--- a/FinalEngine.Rendering.OpenGL/Invocation/OpenGLInvoker.cs
+++ b/FinalEngine.Rendering.OpenGL/Invocation/OpenGLInvoker.cs
@@ -34,7 +34,7 @@ public class OpenGLInvoker : IOpenGLInvoker
         GL.BindBuffer(target, buffer);
     }
 
-    public void Bindframebuffer(FramebufferTarget target, int framebuffers)
+    public void BindFramebuffer(FramebufferTarget target, int framebuffers)
     {
         GL.BindFramebuffer(target, framebuffers);
     }
@@ -424,9 +424,8 @@ public class OpenGLInvoker : IOpenGLInvoker
 
     public void NamedFramebufferDrawBuffers(int fb, int n, ref DrawBuffersEnum bufs)
     {
-        GL.NamedFramebufferDrawBuffers(fb,n,ref bufs);
+        GL.NamedFramebufferDrawBuffers(fb, n, ref bufs);
     }
-
 
     private static void DebugCallback(
         DebugSource source,

--- a/FinalEngine.Rendering.OpenGL/OpenGLGPUResourceFactory.cs
+++ b/FinalEngine.Rendering.OpenGL/OpenGLGPUResourceFactory.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
-using FinalEngine.Rendering.Exceptions;
 using FinalEngine.Rendering.Buffers;
 using FinalEngine.Rendering.OpenGL.Buffers;
 using FinalEngine.Rendering.OpenGL.Invocation;
@@ -32,8 +31,20 @@ public class OpenGLGPUResourceFactory : IGPUResourceFactory
         this.mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
     }
 
+    public IFrameBuffer CreateFrameBuffer(IReadOnlyCollection<ITexture2D> colorTargets, ITexture2D? depthTarget = null)
+    {
+        ArgumentNullException.ThrowIfNull(colorTargets, nameof(colorTargets));
+
+        if (depthTarget is not null and not IOpenGLTexture)
+        {
+            throw new ArgumentException($"The specified {nameof(depthTarget)} parameter is not of type {nameof(IOpenGLTexture)}.", nameof(depthTarget));
+        }
+
+        return new OpenGLFrameBuffer(this.invoker, colorTargets.Cast<IOpenGLTexture>().ToList().AsReadOnly(), (IOpenGLTexture?)depthTarget);
+    }
+
     public IIndexBuffer CreateIndexBuffer<T>(BufferUsageType type, IReadOnlyCollection<T> data, int sizeInBytes)
-        where T : struct
+            where T : struct
     {
         ArgumentNullException.ThrowIfNull(data, nameof(data));
         return new OpenGLIndexBuffer<T>(this.invoker, this.mapper, this.mapper.Forward<BufferUsageHint>(type), data, sizeInBytes);
@@ -78,15 +89,5 @@ public class OpenGLGPUResourceFactory : IGPUResourceFactory
     {
         ArgumentNullException.ThrowIfNull(data, nameof(data));
         return new OpenGLVertexBuffer<T>(this.invoker, this.mapper, this.mapper.Forward<BufferUsageHint>(type), data, sizeInBytes, stride);
-    }
-
-    public IFrameBuffer CreateFrameBuffer(IReadOnlyList<ITexture2D> colorTargets, ITexture2D? depthTarget)
-    {
-        ArgumentNullException.ThrowIfNull(colorTargets, nameof(colorTargets));
-        if (colorTargets.Count > this.invoker.GetInteger(GetPName.MaxColorAttachments))
-        {
-            throw new FrameBufferTargetException($"The number of {nameof(colorTargets)} should not exceed the maximum number of max colorAttachments.");
-        }
-        return new OpenGLFrameBuffer(this.invoker, this.mapper, colorTargets, depthTarget);
     }
 }

--- a/FinalEngine.Rendering.Vapor/RenderingEngine.cs
+++ b/FinalEngine.Rendering.Vapor/RenderingEngine.cs
@@ -17,6 +17,8 @@ using FinalEngine.Resources;
 
 public sealed class RenderingEngine : IRenderingEngine
 {
+    private readonly Light ambientLight;
+
     private readonly IGeometryRenderer geometryRenderer;
 
     private readonly ILightRenderer lightRenderer;
@@ -26,8 +28,6 @@ public sealed class RenderingEngine : IRenderingEngine
     private readonly Dictionary<Model, IEnumerable<Transform>> modelToTransformationMap;
 
     private readonly IRenderDevice renderDevice;
-
-    private Light ambientLight;
 
     private IShaderProgram? geometryProgram;
 

--- a/FinalEngine.Rendering/Buffers/IFrameBuffer.cs
+++ b/FinalEngine.Rendering/Buffers/IFrameBuffer.cs
@@ -1,14 +1,15 @@
+// <copyright file="IFrameBuffer.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
 namespace FinalEngine.Rendering.Buffers;
-using System;
+
 using System.Collections.Generic;
 using FinalEngine.Rendering.Textures;
 
-public interface IFrameBuffer : IDisposable
+public interface IFrameBuffer
 {
+    IEnumerable<ITexture2D> ColorTargets { get; }
+
     ITexture2D? DepthTarget { get; }
-
-    IReadOnlyList<ITexture2D> ColorTargets { get; }
-
-    int Width { get; }
-    int Height { get; }
 }

--- a/FinalEngine.Rendering/Exceptions/FrameBufferNotCompleteException.cs
+++ b/FinalEngine.Rendering/Exceptions/FrameBufferNotCompleteException.cs
@@ -1,4 +1,9 @@
+// <copyright file="FrameBufferNotCompleteException.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
 namespace FinalEngine.Rendering.Exceptions;
+
 using System;
 
 public class FrameBufferNotCompleteException : Exception

--- a/FinalEngine.Rendering/Exceptions/FrameBufferTargetException .cs
+++ b/FinalEngine.Rendering/Exceptions/FrameBufferTargetException .cs
@@ -1,4 +1,9 @@
+// <copyright file="FrameBufferTargetException .cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
 namespace FinalEngine.Rendering.Exceptions;
+
 using System;
 
 public class FrameBufferTargetException : Exception

--- a/FinalEngine.Rendering/IGPUResourceFactory.cs
+++ b/FinalEngine.Rendering/IGPUResourceFactory.cs
@@ -11,8 +11,10 @@ using FinalEngine.Rendering.Textures;
 
 public interface IGPUResourceFactory
 {
+    IFrameBuffer CreateFrameBuffer(IReadOnlyCollection<ITexture2D> colorTargets, ITexture2D? depthTarget = null);
+
     IIndexBuffer CreateIndexBuffer<T>(BufferUsageType type, IReadOnlyCollection<T> data, int sizeInBytes)
-        where T : struct;
+            where T : struct;
 
     IInputLayout CreateInputLayout(IReadOnlyCollection<InputElement> elements);
 
@@ -24,6 +26,4 @@ public interface IGPUResourceFactory
 
     IVertexBuffer CreateVertexBuffer<T>(BufferUsageType type, IReadOnlyCollection<T> data, int sizeInBytes, int stride)
         where T : struct;
-
-    IFrameBuffer CreateFrameBuffer(IReadOnlyList<ITexture2D> colorTargets, ITexture2D? depthTarget);
 }

--- a/FinalEngine.Rendering/IPipeline.cs
+++ b/FinalEngine.Rendering/IPipeline.cs
@@ -12,11 +12,12 @@ using FinalEngine.Rendering.Textures;
 public interface IPipeline
 {
     int MaxTextureSlots { get; }
-    int MaxColorAttachments { get; }
 
     void AddShaderHeader(string name, string content);
 
     string GetShaderHeader(string name);
+
+    void SetFrameBuffer(IFrameBuffer? frameBuffer);
 
     void SetShaderProgram(IShaderProgram program);
 
@@ -37,6 +38,4 @@ public interface IPipeline
     void SetUniform(string name, Vector4 value);
 
     void SetUniform(string name, Matrix4x4 value);
-
-    void SetFrameBuffer(IFrameBuffer? frameBuffer);
 }

--- a/FinalEngine.Tests/Core/Maths/MathHelperTests.cs
+++ b/FinalEngine.Tests/Core/Maths/MathHelperTests.cs
@@ -1,5 +1,5 @@
 // <copyright file="MathHelperTests.cs" company="Software Antics">
-// Copyright (c) Software Antics. All rights reserved.
+//     Copyright (c) Software Antics. All rights reserved.
 // </copyright>
 
 namespace FinalEngine.Tests.Core.Maths;

--- a/FinalEngine.Tests/Core/Resources/Mocks/MockDisposableResource.cs
+++ b/FinalEngine.Tests/Core/Resources/Mocks/MockDisposableResource.cs
@@ -1,5 +1,5 @@
 // <copyright file="MockDisposableResource.cs" company="Software Antics">
-// Copyright (c) Software Antics. All rights reserved.
+//     Copyright (c) Software Antics. All rights reserved.
 // </copyright>
 
 namespace FinalEngine.Tests.Core.Resources.Mocks;

--- a/FinalEngine.Tests/GlobalSuppressions.cs
+++ b/FinalEngine.Tests/GlobalSuppressions.cs
@@ -1,5 +1,5 @@
 // <copyright file="GlobalSuppressions.cs" company="Software Antics">
-// Copyright (c) Software Antics. All rights reserved.
+//     Copyright (c) Software Antics. All rights reserved.
 // </copyright>
 
 using System.Diagnostics.CodeAnalysis;

--- a/FinalEngine.Tests/Rendering/Loaders/Shaders/ShaderResourceLoaderTests.cs
+++ b/FinalEngine.Tests/Rendering/Loaders/Shaders/ShaderResourceLoaderTests.cs
@@ -8,7 +8,6 @@ using System;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using FinalEngine.Rendering;
-using FinalEngine.Rendering.Loaders.Shaders;
 using FinalEngine.Rendering.Pipeline;
 using Moq;
 using NUnit.Framework;

--- a/FinalEngine.Tests/Rendering/Loaders/Textures/Texture2DLoaderTests.cs
+++ b/FinalEngine.Tests/Rendering/Loaders/Textures/Texture2DLoaderTests.cs
@@ -8,8 +8,6 @@ using System;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using FinalEngine.Rendering;
-using FinalEngine.Rendering.Loaders.Invocation;
-using FinalEngine.Rendering.Loaders.Textures;
 using FinalEngine.Rendering.Textures;
 using Moq;
 using NUnit.Framework;

--- a/FinalEngine.Tests/Rendering/Vapor/Geometry/MaterialTests.cs
+++ b/FinalEngine.Tests/Rendering/Vapor/Geometry/MaterialTests.cs
@@ -6,7 +6,6 @@ namespace FinalEngine.Tests.Rendering.Vapor.Geometry;
 
 using System;
 using FinalEngine.Rendering;
-using FinalEngine.Rendering.Geometry;
 using FinalEngine.Rendering.Textures;
 using FinalEngine.Resources;
 using Moq;

--- a/FinalEngine.Tests/Rendering/Vapor/Geometry/MeshTests.cs
+++ b/FinalEngine.Tests/Rendering/Vapor/Geometry/MeshTests.cs
@@ -1,5 +1,5 @@
 // <copyright file="MeshTests.cs" company="Software Antics">
-// Copyright (c) Software Antics. All rights reserved.
+//     Copyright (c) Software Antics. All rights reserved.
 // </copyright>
 
 namespace FinalEngine.Tests.Rendering.Vapor.Geometry;
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Numerics;
 using FinalEngine.Rendering;
 using FinalEngine.Rendering.Buffers;
-using FinalEngine.Rendering.Geometry;
 using Moq;
 using NUnit.Framework;
 

--- a/FinalEngine.Tests/Rendering/Vapor/Primitives/MeshVertexTests.cs
+++ b/FinalEngine.Tests/Rendering/Vapor/Primitives/MeshVertexTests.cs
@@ -1,5 +1,5 @@
 // <copyright file="MeshVertexTests.cs" company="Software Antics">
-// Copyright (c) Software Antics. All rights reserved.
+//     Copyright (c) Software Antics. All rights reserved.
 // </copyright>
 
 namespace FinalEngine.Tests.Rendering.Vapor.Primitives;
@@ -7,7 +7,6 @@ namespace FinalEngine.Tests.Rendering.Vapor.Primitives;
 using System.Linq;
 using System.Numerics;
 using FinalEngine.Rendering.Buffers;
-using FinalEngine.Rendering.Geometry;
 using NUnit.Framework;
 
 [TestFixture]

--- a/FinalEngine.Tests/Rendering/Vapor/Primitives/SpriteVertexTests.cs
+++ b/FinalEngine.Tests/Rendering/Vapor/Primitives/SpriteVertexTests.cs
@@ -6,7 +6,6 @@ namespace FinalEngine.Tests.Rendering.Vapor.Primitives;
 
 using System.Collections.Generic;
 using System.Numerics;
-using FinalEngine.Rendering;
 using FinalEngine.Rendering.Buffers;
 using NUnit.Framework;
 

--- a/FinalEngine.Tests/Runtime/Rendering/DisplayManagerTests.cs
+++ b/FinalEngine.Tests/Runtime/Rendering/DisplayManagerTests.cs
@@ -1,5 +1,5 @@
 // <copyright file="DisplayManagerTests.cs" company="Software Antics">
-// Copyright (c) Software Antics. All rights reserved.
+//     Copyright (c) Software Antics. All rights reserved.
 // </copyright>
 
 namespace FinalEngine.Tests.Runtime.Rendering;


### PR DESCRIPTION
- Added example in `Program.cs`
- Removed `UnBind` function in `IOpenGLFrameBuffer` - You should never need to unbind a framebuffer, only "rebind" the windows frame buffer.
- Removed redundant "width" and "height" properties for the frame buffer - a frame buffer can have multiple textures of different sizes.
- Fixed up styling and naming issues throughout the code base using CodeMaid.
- Removed `MaxColorAttachments` from `IPipeline` as currently it doesn't need to be there.